### PR TITLE
New basic DMP export formats

### DIFF
--- a/src/elm/DSPlanner/Index/View.elm
+++ b/src/elm/DSPlanner/Index/View.elm
@@ -75,6 +75,11 @@ exportFormats : List ( String, String )
 exportFormats =
     [ ( "json", "JSON Data" )
     , ( "html", "HTML Document" )
+    , ( "pdf", "PDF Document" )
+    , ( "latex", "LaTeX Document" )
+    , ( "docx", "MS Word Document" )
+    , ( "odt", "OpenDocument Text" )
+    , ( "markdown", "Markdown Document" )
     ]
 
 


### PR DESCRIPTION
Adding PDF, LaTeX, Docx, ODT, and Markdown as possible export formats of DMPs